### PR TITLE
Bump version to 1.0.48

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,12 +2,12 @@
 # It is not intended for manual editing.
 [[package]]
 name = "astexplorer-syn"
-version = "1.0.46"
+version = "1.0.48"
 dependencies = [
  "proc-macro2",
  "quote",
  "serde_json",
- "syn 1.0.46",
+ "syn 1.0.48",
  "syn-codegen",
  "wasm-bindgen",
 ]
@@ -137,7 +137,7 @@ checksum = "cbd1ae72adb44aab48f325a02444a5fc079349a8d804c1fc922aed3f7454c74e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.46 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -153,7 +153,7 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.46"
+version = "1.0.48"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -162,9 +162,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.46"
+version = "1.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ad5de3220ea04da322618ded2c42233d02baca219d6f160a3e9c87cda16c942"
+checksum = "cc371affeffc477f42a221a1e4297aedcea33d47d19b61455588bd9d8f6b19ac"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -215,7 +215,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 1.0.46 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen-shared",
 ]
 
@@ -237,7 +237,7 @@ checksum = "f249f06ef7ee334cc3b8ff031bfc11ec99d00f34d86da7498396dc1e3b1498fe"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.46 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astexplorer-syn"
-version = "1.0.46"
+version = "1.0.48"
 authors = ["Ingvar Stepanyan <me@rreverser.com>"]
 edition = "2018"
 
@@ -9,7 +9,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 proc-macro2 = { version = "1.0", features = ["span-locations"] }
-syn = { version = "=1.0.46", path = "syn", default-features = false, features = ["derive", "parsing", "printing", "full"] }
+syn = { version = "=1.0.48", path = "syn", default-features = false, features = ["derive", "parsing", "printing", "full"] }
 wasm-bindgen = "0.2.39"
 
 [build-dependencies]


### PR DESCRIPTION
The package published as 1.0.46 has some files missing:

```console
ERROR in ./node_modules/astexplorer-syn/astexplorer_syn.js
Module not found: Error: Can't resolve './astexplorer_syn_bg.js' in 'astexplorer/website/node_modules/astexplorer-syn'
 @ ./node_modules/astexplorer-syn/astexplorer_syn.js 2:0-40 2:0-40
 @ ./src/parsers/rust/syn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^\/]+\/(transformers\/([^\/]+)\/)?(codeExample\.txt|[^\/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/gist.js
 @ ./src/app.js

ERROR in ./node_modules/astexplorer-syn/astexplorer_syn_bg.wasm
Module not found: Error: Can't resolve './astexplorer_syn_bg.js' in 'astexplorer/website/node_modules/astexplorer-syn'
 @ ./node_modules/astexplorer-syn/astexplorer_syn_bg.wasm
 @ ./node_modules/astexplorer-syn/astexplorer_syn.js
 @ ./src/parsers/rust/syn.js
 @ ./src/parsers sync ^\.\/(?!utils|transpilers)[^\/]+\/(transformers\/([^\/]+)\/)?(codeExample\.txt|[^\/]+?\.js)$
 @ ./src/parsers/index.js
 @ ./src/storage/gist.js
 @ ./src/app.js
```

I had to manually add "astexplorer_syn_bg.js" and "astexplorer_syn_bg.wasm.d.ts" to the wasm-pack generated package.json for it to work. :(